### PR TITLE
Feat/#131 로그아웃시 authToken 클라이언트에서 제거

### DIFF
--- a/FITple-Frontend/src/pages/ProfilePage/ProfilePage.jsx
+++ b/FITple-Frontend/src/pages/ProfilePage/ProfilePage.jsx
@@ -16,7 +16,7 @@ import Infom from "../../components/Infom/Infom";
 import { useNavigate } from "react-router-dom";
 import { getInform } from "../../../data/ProfileApi";
 import { logout } from "../../../data/LoginApi";
-
+import Cookies from "js-cookie";
 const ProfilePage = () => {
   const navigate = useNavigate();
   const [selectItem, setSelectItem] = useState(0);
@@ -50,9 +50,11 @@ const ProfilePage = () => {
 
   // 로그아웃 함수
   const handleLogout = async () => {
+    // 로그아웃을 통해 accessToken, refreshToken 제거
     const response = await logout();
+    // authToken 쿠키 삭제
+    Cookies.remove("authToken");
     navigate("/");
-    console.log("response");
   };
   useEffect(() => {
     getProfileData();


### PR DESCRIPTION
## 💻 Feature 설명
> 현재 로그아웃시 accessToken, refreshToken만 삭제되서 쿠키에서 authToken제거
<br>

## 📝 To-do
**메인주제**
- [x] 쿠키에서 authToken제거
<br>

## 📸 스크린샷

https://github.com/user-attachments/assets/e536faf7-8109-4c03-a5a1-97c3a631e65e

로그아웃시  accessToken, refreshToken ,authToken 모두 삭제되게 설정

<br>

## 📚 참고문헌 / 기타
- 